### PR TITLE
Set expires headers on 404/403 errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,6 @@ function decode(encoded) {
     }
 
     data.headers['x-redis'] = 'hit';
-    data.buffer = encoded.slice(offset);
 
     if (data.headers['x-redis-err']) {
         var err = new Error();
@@ -206,6 +205,8 @@ function decode(encoded) {
         err.redis = true;
         return { err: err };
     }
+
+    data.buffer = encoded.slice(offset);
 
     // Return JSON-encoded objects to true form.
     if (data.headers['x-redis-json']) data.buffer = JSON.parse(data.buffer);

--- a/index.js
+++ b/index.js
@@ -189,7 +189,12 @@ function decode(encoded) {
     // First 1024 bytes reserved for header + padding.
     var offset = 1024;
     var data = {};
-    data.headers = encoded.slice(0, offset).toString().trim();
+    // If 1024 or less, then it is only headers
+    if (encoded.length > 1024) {
+        data.headers = encoded.slice(0, offset).toString().trim();
+    } else {
+        data.headers = encoded;
+    }
 
     try {
         data.headers = JSON.parse(data.headers);

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ function decode(encoded) {
         var err = new Error();
         err.statusCode = parseInt(data.headers['x-redis-err'], 10);
         err.redis = true;
-        return { err: err };
+        return { err: err, headers: data.headers };
     }
 
     data.buffer = encoded.slice(offset);

--- a/test/test.js
+++ b/test/test.js
@@ -432,7 +432,7 @@ describe('cachingGet', function() {
         wrapped('missing', function(err, data, headers) {
             assert.equal(err.toString(), 'Error: Not found', 'not found err');
             assert.equal(err.statusCode, 404, 'err statusCode 404');
-            assert.deepEqual(Object.keys(headers), ['x-redis-expires'], 'sets x-redis-expires header');
+            assert.deepEqual(Object.keys(headers), ['x-redis-expires', 'x-redis-err'], 'sets x-redis-expires header');
             assert.equal(stats.missing, 1, 'missing IO x1');
             done();
         });
@@ -489,8 +489,12 @@ describe('unit', function() {
         var errstatCode404 = new Error(); errstatCode404.statusCode = 404;
         var errstatCode403 = new Error(); errstatCode403.statusCode = 403;
         var errstatCode500 = new Error(); errstatCode500.statusCode = 500;
-        assert.equal(Redsource.encode(errstatCode404), '404');
-        assert.equal(Redsource.encode(errstatCode403), '403');
+        assert.ok(bufferEqual(Redsource.encode(errstatCode404), new Buffer(
+            '{"x-redis-err":"404"}'
+        )));
+        assert.ok(bufferEqual(Redsource.encode(errstatCode403), new Buffer(
+            '{"x-redis-err":"403"}'
+        )));
         assert.equal(Redsource.encode(errstatCode500), null);
 
         assert.ok(bufferEqual(Redsource.encode(null, {id:'foo'}), new Buffer(

--- a/test/testsource.js
+++ b/test/testsource.js
@@ -36,13 +36,14 @@ Testsource.prototype.get = function(url, callback) {
     var stat = this.stat;
 
     if (this.delay) {
+        stat.get++;
         setTimeout(function() { get(url, callback); }, this.delay);
     } else {
+        stat.get++;
         get();
     }
 
     function get() {
-        stat.get++;
         switch (url) {
         case 'http://test/0/0/0.png':
             return callback(null, tiles.a, {


### PR DESCRIPTION
Refs #23 

Sets expires headers on 404/403's.  Is backward compatible with handling any cached 404/403s that do not have any headers (ie. is still able to decode these).

- [x] Test that does not do IO
- [x] Put back test showing that it can still decode simple 404/403