### PR TITLE
Add command timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ It wraps `node-tilejson`, providing a new source constructor with redis superpow
     var options = {
         client: client,             // optional, instantiated redis client
         ttl: <number> or <object>,  // optional, object cache ttl in seconds
-        stale: <number> or <object> // optional, max number of seconds to allow a stale object to be served
+        stale: <number> or <object>,// optional, max number of seconds to allow a stale object to be served
+        timeout: <number>           // optional, max ms to wait before bypassing redis. Defaults to 50
     };
     var TileJSON = require('tilelive-redis')(options, require('tilejson'));
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports.cachingGet = function(namespace, options, get) {
             return get.call(source, url, callback);
         }
 
-        client.get(key, timeoutAfter(function(err, encoded) {
+        client.get(key, timeoutAfter(function redisGet(err, encoded) {
             // If error on redis get, pass through to original source
             // without attempting a set after retrieval.
             if (err) {
@@ -127,7 +127,7 @@ module.exports.cachingGet = function(namespace, options, get) {
             // so that the upstream expires is fully respected.
             var pad = expires ? 0 : stale;
 
-            if (sec > 0) client.setex(key, sec + pad, encode(err, buffer, headers), timeoutAfter(function(err) {
+            if (sec > 0) client.setex(key, sec + pad, encode(err, buffer, headers), timeoutAfter(function redisSetEx(err) {
                 if (!err) return;
                 err.key = key;
                 client.emit('error', err);
@@ -142,9 +142,7 @@ module.exports.cachingGet = function(namespace, options, get) {
 
             return (+(new Date(d.headers['x-redis-expires'])) > Date.now());
         }
-    }
-
-    return caching;
+    };
 };
 
 module.exports.redis = redis;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "buffer-equal": "0.0.1",
+    "callback-timeout": "2.1.0",
     "redis": "0.12.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds a redis command timeout -- if the redis client does not complete the `get()` or `setex()` operations within the specified `timeout` (for _whatever_ reason) errors and moves on to using the backend I/O.

Sets a default operation timeout of 50ms.

cc @emilymcafee @jakepruitt 