### PR TITLE
Use redis 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
+  - "4"
+  - "6"
 
 services:
   - redis-server

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "buffer-equal": "0.0.1",
     "callback-timeout": "2.1.0",
-    "redis": "0.12.1"
+    "redis": "2.6.5"
   },
   "devDependencies": {
     "buffer-equal": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
   },
   "scripts": {
     "test": "mocha -R spec"
-  },
-  "engines": {
-    "node": "0.8.x || 0.10.x"
   }
 }


### PR DESCRIPTION
We have been pinned to node-redis v0.12.1 (released in [aug, 2014](https://github.com/NodeRedis/node_redis/blob/master/changelog.md#v0121---aug-10-2014)) [since the beginning](https://github.com/mapbox/tilelive-redis/commit/ca62b8f1a78c75f2957ffb739b3170cd4a4a285d). This PR upgrades to the latest version with the aim to test how more recent releases work with proxies that might not support the redis INFO command. Refs https://github.com/NodeRedis/node_redis/issues/704. Will need to be aware of upgrade issues like https://github.com/NodeRedis/node_redis/issues/1113
