### PR TITLE
Update to mapbox namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tilelive-redis",
+  "name": "@mapbox/tilelive-redis",
   "version": "1.2.0",
   "main": "./index.js",
   "description": "redis wrapping source for tilelive",
@@ -13,7 +13,6 @@
     "redis": "0.12.1"
   },
   "devDependencies": {
-    "buffer-equal": "0.0.x",
     "mocha": "1.3.x"
   },
   "scripts": {


### PR DESCRIPTION
After merge run following:
- [ ] Run `npm publish --access=public` to publish the first namespaced version
- [ ] Run `npm deprecate tilelive-redis "This module has moved: please install @mapbox/tilelive-redis instead"`

/cc @springmeyer @ianshward for review