### PR TITLE
Remove redis timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var urlParse = require('url').parse;
 var util = require('util');
 var redis = require('redis');
-var timeoutAfter = require('callback-timeout');
 
 module.exports = function(options, Source) {
     if (!Source) throw new Error('No source provided');
@@ -39,9 +38,6 @@ module.exports.cachingGet = function(namespace, options, get) {
         var source = this;
         var client = options.client;
 
-        // Timeout redis operations @ 50ms by default
-        var timeout = options.timeout || 50;
-
         var ttl = 300;
         var stale = 300;
 
@@ -64,7 +60,7 @@ module.exports.cachingGet = function(namespace, options, get) {
             return get.call(source, url, callback);
         }
 
-        client.get(key, timeoutAfter(function redisGet(err, encoded) {
+        client.get(key, function redisGet(err, encoded) {
             // If error on redis get, pass through to original source
             // without attempting a set after retrieval.
             if (err) {
@@ -102,7 +98,7 @@ module.exports.cachingGet = function(namespace, options, get) {
                     callback(err, buffer, headers);
                 });
             }
-        }, timeout));
+        });
 
         function setEx(key, err, buffer, headers, ttl, stale) {
             var expires = headers.Expires || headers.expires;
@@ -126,11 +122,11 @@ module.exports.cachingGet = function(namespace, options, get) {
             // so that the upstream expires is fully respected.
             var pad = expires ? 0 : stale;
 
-            if (sec > 0) client.setex(key, sec + pad, encode(err, buffer, headers), timeoutAfter(function redisSetEx(err) {
+            if (sec > 0) client.setex(key, sec + pad, encode(err, buffer, headers), function redisSetEx(err) {
                 if (!err) return;
                 err.key = key;
                 client.emit('error', err);
-            }, timeout));
+            });
 
             return headers;
         }

--- a/test/test.js
+++ b/test/test.js
@@ -659,69 +659,6 @@ describe('cachingGet with key patterns', function() {
     });
 });
 
-describe('cachingGet timeout', function() {
-    var stats = {};
-    var getter = function(id, callback) {
-        stats[id] = stats[id] || 0;
-        stats[id]++;
-        return callback(null, {id:id}, { expires: (new Date(Date.now() + (100 * 1000))).toUTCString() });
-    };
-
-    // Test that get commands timeout
-    it('client.get timeout', function(done) {
-        var options = {
-            client: {
-                command_queue: [],
-                options: {},
-                emit: function(event, err) {
-                    assert.equal(event, 'error');
-                    assert.equal(err.toString(), 'TimeoutError: timeout of 50ms exceeded for callback redisGet');
-                },
-                get: function(id, callback) {
-                    setTimeout(function() { callback(); }, 1000);
-                }
-            }
-        };
-        var wrapped = Redsource.cachingGet('test', options, getter);
-        wrapped('asdf', function(err, data, headers) {
-            assert.ifError(err);
-            assert.deepEqual(data, {id:'asdf'}, 'returns data');
-            assert.deepEqual(Object.keys(headers), [ 'expires' ], 'sets headers');
-            assert.equal(stats.asdf, 1, 'asdf IO x1');
-            done();
-        });
-    });
-
-    // Test that setex commands timeout
-    it('client.setex timeout', function(done) {
-        var options = {
-            client: {
-                command_queue: [],
-                options: {},
-                emit: function(event, err) {
-                    assert.equal(event, 'error');
-                    assert.equal(err.toString(), 'TimeoutError: timeout of 50ms exceeded for callback redisSetEx');
-                },
-                get: function(id, callback) {
-                    callback();
-                },
-                setex: function(id, expires, data, callback) {
-                    setTimeout(function() { callback(); }, 1000);
-                }
-            }
-        };
-        var wrapped = Redsource.cachingGet('test', options, getter);
-        wrapped('asdf', function(err, data, headers) {
-            assert.ifError(err);
-            assert.deepEqual(data, {id:'asdf'}, 'returns data');
-            assert.deepEqual(Object.keys(headers), ['expires', 'x-redis-expires', 'x-redis-json'], 'sets x-redis headers');
-            setTimeout(function() {
-                done();
-            }, 100);
-        });
-    });
-});
-
 describe('unit', function() {
     it('encode', function(done) {
         var errstatCode404 = new Error(); errstatCode404.statusCode = 404;


### PR DESCRIPTION
Canary for https://github.com/mapbox/api-maps/issues/1348

**Update** rather than remove the timeout in tilelive-redis. I am opening a PR in api-maps with a significantly elevated timeout time to simulate no timeout. This will be easier to iterate on, avoiding the dev release cycle for tilelive-redis.