### PR TITLE
Enable testing with node v10 + coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
 language: node_js
-node_js:
-  - "0.10"
-  - "4"
-  - "6"
 
 services:
   - redis-server
 
 sudo: false
+
+matrix:
+ include:
+   - node_js: 6
+     script:
+       - npm run coverage
+   - node_js: 6
+     script:
+       - npm test
+   - node_js: 8
+     script:
+       - npm test
+   - node_js: 10
+     script:
+       - npm run coverage

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   },
   "devDependencies": {
     "buffer-equal": "0.0.1",
-    "mocha": "1.3.x"
+    "codecov": "^3.0.4",
+    "mocha": "1.3.x",
+    "nyc": "^12.0.2"
   },
   "scripts": {
-    "test": "mocha -R spec"
-  },
-  "engines": {
-    "node": "0.8.x || 0.10.x"
+    "test": "mocha -R spec",
+    "coverage": "nyc npm run test && nyc report --reporter=text-lcov > coverage.lcov && codecov"
   }
 }


### PR DESCRIPTION
This adds:
 - node v10 testing support to travis
 - starts running code coverage and posts to codecov.io

And drops:
 - testing with node v0.10
 - the `engines` in package.json (this gets out of date too fast)