### PR TITLE
Avoid deprecated Buffer usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 services:
   - redis-server
 
-sudo: false
-
 matrix:
  include:
    - node_js: 6

--- a/index.js
+++ b/index.js
@@ -210,8 +210,7 @@ function encode(err, buffer, headers) {
         throw new Error('Invalid cache value - headers exceed 1024 bytes: ' + JSON.stringify(headers));
     }
 
-    var padding = Buffer.allocUnsafe(1024 - headers.length);
-    padding.fill(' ');
+    var padding = Buffer.alloc(1024 - headers.length, ' ');
     var len = headers.length + padding.length + buffer.length;
     return Buffer.concat([headers, padding, buffer], len);
 };

--- a/index.js
+++ b/index.js
@@ -191,26 +191,26 @@ function encode(err, buffer, headers) {
 
     if (err)  {
         headers['x-redis-err'] = errcode(err).toString();
-        headers = new Buffer(JSON.stringify(headers), 'utf8');
+        headers = Buffer.from(JSON.stringify(headers), 'utf8');
         return headers;
     }
 
     // Turn objects into JSON string buffers.
     if (buffer && typeof buffer === 'object' && !(buffer instanceof Buffer)) {
         headers['x-redis-json'] = true;
-        buffer = new Buffer(JSON.stringify(buffer));
+        buffer = Buffer.from(JSON.stringify(buffer));
     // Turn strings into buffers.
     } else if (buffer && !(buffer instanceof Buffer)) {
-        buffer = new Buffer(buffer);
+        buffer = Buffer.from(buffer);
     }
 
-    headers = new Buffer(JSON.stringify(headers), 'utf8');
+    headers = Buffer.from(JSON.stringify(headers), 'utf8');
 
     if (headers.length > 1024) {
         throw new Error('Invalid cache value - headers exceed 1024 bytes: ' + JSON.stringify(headers));
     }
 
-    var padding = new Buffer(1024 - headers.length);
+    var padding = Buffer.allocUnsafe(1024 - headers.length);
     padding.fill(' ');
     var len = headers.length + padding.length + buffer.length;
     return Buffer.concat([headers, padding, buffer], len);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-redis",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha1",
   "main": "./index.js",
   "description": "redis wrapping source for tilelive",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-redis",
-  "version": "1.4.0-alpha2.0",
+  "version": "1.4.0",
   "main": "./index.js",
   "description": "redis wrapping source for tilelive",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-redis",
-  "version": "1.4.0-alpha1",
+  "version": "1.4.0-alpha2.0",
   "main": "./index.js",
   "description": "redis wrapping source for tilelive",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -727,40 +727,40 @@ describe('unit', function() {
         var errstatCode404 = new Error(); errstatCode404.statusCode = 404;
         var errstatCode403 = new Error(); errstatCode403.statusCode = 403;
         var errstatCode500 = new Error(); errstatCode500.statusCode = 500;
-        assert.ok(bufferEqual(Redsource.encode(errstatCode404), new Buffer(
+        assert.ok(bufferEqual(Redsource.encode(errstatCode404), Buffer.from(
             '{"x-redis-err":"404"}'
         )));
-        assert.ok(bufferEqual(Redsource.encode(errstatCode403), new Buffer(
+        assert.ok(bufferEqual(Redsource.encode(errstatCode403), Buffer.from(
             '{"x-redis-err":"403"}'
         )));
         assert.equal(Redsource.encode(errstatCode500), null);
 
-        assert.ok(bufferEqual(Redsource.encode(null, {id:'foo'}), new Buffer(
+        assert.ok(bufferEqual(Redsource.encode(null, {id:'foo'}), Buffer.from(
             '{"x-redis-json":true}' +
             new Array(1025 - '{"x-redis-json":true}'.length).join(' ') +
             '{"id":"foo"}'
         )), 'encodes object');
 
-        assert.ok(bufferEqual(Redsource.encode(null, 'hello world'), new Buffer(
+        assert.ok(bufferEqual(Redsource.encode(null, 'hello world'), Buffer.from(
             '{}' +
             new Array(1025 - '{}'.length).join(' ') +
             'hello world'
         ), 'encodes string'));
 
-        assert.ok(bufferEqual(Redsource.encode(null, new Buffer(0)), new Buffer(
+        assert.ok(bufferEqual(Redsource.encode(null, Buffer.alloc(0)), Buffer.from(
             '{}' +
             new Array(1025 - '{}'.length).join(' ') +
             ''
         ), 'encodes empty buffer'));
 
-        assert.ok(bufferEqual(Redsource.encode(null, new Buffer(0), { 'content-type': 'image/png' }), new Buffer(
+        assert.ok(bufferEqual(Redsource.encode(null, Buffer.alloc(0), { 'content-type': 'image/png' }), Buffer.from(
             '{"content-type":"image/png"}' +
             new Array(1025 - '{"content-type":"image/png"}'.length).join(' ') +
             ''
         ), 'encodes headers'));
 
         assert.throws(function() {
-            Redsource.encode(null, new Buffer(0), { data: new Array(1024).join(' ') });
+            Redsource.encode(null, Buffer.alloc(0), { data: new Array(1024).join(' ') });
         }, Error, 'throws when headers exceed 1024 bytes');
 
         done();
@@ -770,17 +770,17 @@ describe('unit', function() {
         assert.deepEqual(Redsource.decode('403'), {err:{statusCode:403,redis:true}});
 
         assert.deepEqual(
-            Redsource.decode(new Buffer('{"x-redis-err":"404","x-redis":"hit"}')),
+            Redsource.decode(Buffer.from('{"x-redis-err":"404","x-redis":"hit"}')),
             {err:{statusCode:404,redis:true}, headers:{'x-redis-err': '404','x-redis': 'hit'}}
         );
 
         assert.deepEqual(
-            Redsource.decode(new Buffer('{"x-redis-err":"403","x-redis":"hit"}')),
+            Redsource.decode(Buffer.from('{"x-redis-err":"403","x-redis":"hit"}')),
             {err:{statusCode:403,redis:true}, headers:{'x-redis-err': '403','x-redis': 'hit'}}
         );
 
         var headers = JSON.stringify({'x-redis-json':true,'x-redis':'hit'});
-        var encoded = new Buffer(
+        var encoded = Buffer.from(
             headers +
             new Array(1025 - headers.length).join(' ') +
             JSON.stringify({'id':'foo'})
@@ -791,28 +791,28 @@ describe('unit', function() {
         }, 'decodes object');
 
         var headers = JSON.stringify({'x-redis':'hit'});
-        var encoded = new Buffer(
+        var encoded = Buffer.from(
             headers +
             new Array(1025 - headers.length).join(' ') +
             'hello world'
         );
         assert.deepEqual(Redsource.decode(encoded), {
             headers:{'x-redis':'hit'},
-            buffer: new Buffer('hello world'),
+            buffer: Buffer.from('hello world'),
         }, 'decodes string (as buffer)');
 
         var headers = JSON.stringify({'x-redis':'hit'});
-        var encoded = new Buffer(
+        var encoded = Buffer.from(
             headers +
             new Array(1025 - headers.length).join(' ') +
             ''
         );
         assert.deepEqual(Redsource.decode(encoded), {
             headers:{'x-redis':'hit'},
-            buffer: new Buffer(0),
+            buffer: Buffer.alloc(0),
         }, 'decodes empty buffer');
 
-        var encoded = new Buffer('bogus');
+        var encoded = Buffer.from('bogus');
         assert.throws(function() {
             Redsource.decode(encoded);
         }, Error, 'throws when encoded buffer does not include headers');


### PR DESCRIPTION
The `new Buffer()` signature is deprecated with recent node versions. The impact of this is not minor since recent node versions have expensive logic at https://github.com/nodejs/node/blob/425357a11c40f3f6d39dba85feb8533ad038aa6e/lib/buffer.js#L148-L160 to decide whether and how to warn the user.

I've seen https://github.com/nodejs/node/blob/425357a11c40f3f6d39dba85feb8533ad038aa6e/lib/buffer.js#L148-L160 show up as a non-trivial % of CPU, so this should lead to a speedup in downstream modules.

This is a stopgap until this dependency can be fully avoided in downstream applications.

/cc @mapbox/maps-api @mapbox/static-apis 